### PR TITLE
Clarify error message

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -123,7 +123,7 @@ def collect_deps(label, deps, proc_macro_deps, aliases, toolchain):
         if CrateInfo in dep:
             if dep[CrateInfo].type == "proc-macro":
               fail(
-                  "{} listed {} in its deps, but it is a proc-macro. It should instead be in proc-macro-deps.".format(
+                  "{} listed {} in its deps, but it is a proc-macro. It should instead be in the bazel property proc_macro_deps.".format(
                       label,
                       dep.label,
                   )


### PR DESCRIPTION
The error message refers to `proc-macro-deps`, which is a string that only exists in this file. Updating the reference to say `proc_macro_deps` which is a common string in the repo and is well documented.